### PR TITLE
Feat/6 search place

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.6'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.6'
+
+	// WebFlux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/config/WebClientConfig.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package goormton.backend.sodamsodam.domain.place.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient kakaoWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://dapi.kakao.com")
+                .build();
+    }
+} 

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/controller/PlaceController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/controller/PlaceController.java
@@ -1,0 +1,41 @@
+package goormton.backend.sodamsodam.domain.place.controller;
+
+import goormton.backend.sodamsodam.domain.place.dto.PlaceResponseDto;
+import goormton.backend.sodamsodam.domain.place.service.PlaceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/places")
+@RequiredArgsConstructor
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @GetMapping("/keyword")
+    public ResponseEntity<List<PlaceResponseDto>> searchPlaces(
+            @RequestParam String query,
+            @RequestParam(required = false) String x,
+            @RequestParam(required = false) String y,
+            @RequestParam(required = false) Integer radius) {
+
+        List<PlaceResponseDto> places = placeService.searchPlaces(query, x, y, radius);
+        return ResponseEntity.ok(places);
+    }
+
+    @GetMapping("/category")
+    public ResponseEntity<List<PlaceResponseDto>> searchByCategory(
+            @RequestParam String category_group_code,
+            @RequestParam(required = false) String x,
+            @RequestParam(required = false) String y,
+            @RequestParam(required = false) Integer radius) {
+
+        List<PlaceResponseDto> places = placeService.searchByCategory(category_group_code, x, y, radius);
+        return ResponseEntity.ok(places);
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/controller/PlaceController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/controller/PlaceController.java
@@ -2,6 +2,13 @@ package goormton.backend.sodamsodam.domain.place.controller;
 
 import goormton.backend.sodamsodam.domain.place.dto.PlaceResponseDto;
 import goormton.backend.sodamsodam.domain.place.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -13,27 +20,44 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/places")
 @RequiredArgsConstructor
+@Tag(name = "Place", description = "장소 검색 API")
 public class PlaceController {
 
     private final PlaceService placeService;
 
+    @Operation(summary = "키워드로 장소 검색", description = "키워드를 기반으로 장소를 검색합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검색 성공",
+            content = @Content(schema = @Schema(implementation = PlaceResponseDto.class))),
+    })
     @GetMapping("/keyword")
-    public ResponseEntity<List<PlaceResponseDto>> searchPlaces(
-            @RequestParam String query,
-            @RequestParam(required = false) String x,
-            @RequestParam(required = false) String y,
-            @RequestParam(required = false) Integer radius) {
+    public ResponseEntity<List<PlaceResponseDto>> searchByKeyword(
+            @Parameter(description = "검색 키워드", required = true) @RequestParam String query,
+            @Parameter(description = "중심 좌표의 X 혹은 경도(longitude) 값\n" +
+                    "특정 지역을 중심으로 검색할 경우 radius와 함께 사용 가능)") @RequestParam(required = false) String x,
+            @Parameter(description = "중심 좌표의 Y 혹은 위도(latitude) 값\n" +
+                    "특정 지역을 중심으로 검색할 경우 radius와 함께 사용 가능") @RequestParam(required = false) String y,
+            @Parameter(description = "중심 좌표부터의 반경거리. 특정 지역을 중심으로 검색하려고 할 경우 중심좌표로 쓰일 x,y와 함께 사용\n" +
+                    "(단위: 미터(m), 최소: 0, 최대: 20000)") @RequestParam(required = false) Integer radius) {
 
-        List<PlaceResponseDto> places = placeService.searchPlaces(query, x, y, radius);
+        List<PlaceResponseDto> places = placeService.searchByKeyword(query, x, y, radius);
         return ResponseEntity.ok(places);
     }
 
+    @Operation(summary = "카테고리로 장소 검색", description = "카테고리 코드를 기반으로 장소를 검색합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검색 성공",
+            content = @Content(schema = @Schema(implementation = PlaceResponseDto.class))),
+    })
     @GetMapping("/category")
     public ResponseEntity<List<PlaceResponseDto>> searchByCategory(
-            @RequestParam String category_group_code,
-            @RequestParam(required = false) String x,
-            @RequestParam(required = false) String y,
-            @RequestParam(required = false) Integer radius) {
+            @Parameter(description = "카테고리 그룹 코드", required = true) @RequestParam String category_group_code,
+            @Parameter(description = "중심 좌표의 X값 혹은 longitude\n" +
+                    "특정 지역을 중심으로 검색하려고 할 경우 radius와 함께 사용 가능.") @RequestParam(required = false) String x,
+            @Parameter(description = "중심 좌표의 Y값 혹은 latitude\n" +
+                    "특정 지역을 중심으로 검색하려고 할 경우 radius와 함께 사용 가능.") @RequestParam(required = false) String y,
+            @Parameter(description = "중심 좌표부터의 반경거리. 특정 지역을 중심으로 검색하려고 할 경우 중심좌표로 쓰일 x,y와 함께 사용\n" +
+                    "(단위: 미터(m), 최소: 0, 최대: 20000)") @RequestParam(required = false) Integer radius) {
 
         List<PlaceResponseDto> places = placeService.searchByCategory(category_group_code, x, y, radius);
         return ResponseEntity.ok(places);

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/dto/KakaoApiResponseDto.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/dto/KakaoApiResponseDto.java
@@ -1,0 +1,34 @@
+package goormton.backend.sodamsodam.domain.place.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class KakaoApiResponseDto {
+
+    private Meta meta;
+    private List<Document> documents;
+
+    @Data
+    public static class Meta {
+        private int total_count;      // 검색된 문서 수
+        private int pageable_count;   // total_count 중 노출 가능 문서 수
+        private boolean is_end;       // 현재 페이지가 마지막 페이지인지 여부
+    }
+
+    @Data
+    public static class Document {
+        private String id;
+        private String place_name;         // 장소명
+        private String category_name;      // 카테고리 이름
+        private String category_group_code; // 카테고리 그룹 코드 (ex. FD6, CE7 등)
+        private String category_group_name; // 카테고리 그룹명
+        private String phone;              // 전화번호
+        private String address_name;       // 지번 주소
+        private String road_address_name;  // 도로명 주소
+        private String place_url;          // 장소 상세 페이지 URL
+        private String distance;           // 중심 좌표까지의 거리 (category 검색 시에만 제공)
+        private String x;                  // 경도
+        private String y;                  // 위도
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/dto/PlaceResponseDto.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/dto/PlaceResponseDto.java
@@ -1,0 +1,22 @@
+package goormton.backend.sodamsodam.domain.place.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceResponseDto {
+    private String placeName;   // 장소명, 업체명
+    private String phone;       // 전화 번호
+    private String addressName; // 전체 지번 주소
+
+    public static PlaceResponseDto from(KakaoApiResponseDto.Document document) {
+        return new PlaceResponseDto(
+                document.getPlace_name(),
+                document.getPhone(),
+                document.getAddress_name()
+        );
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/dto/PlaceResponseDto.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/dto/PlaceResponseDto.java
@@ -1,5 +1,6 @@
 package goormton.backend.sodamsodam.domain.place.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,9 +9,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PlaceResponseDto {
-    private String placeName;   // 장소명, 업체명
-    private String phone;       // 전화 번호
-    private String addressName; // 전체 지번 주소
+    @Schema(description = "장소명 또는 업체명", example = "카카오프렌즈 롯데월드몰 잠실점")
+    private String placeName;
+
+    @Schema(description = "전화번호", example = "02-3213-4514")
+    private String phone;
+
+    @Schema(description = "전체 지번 주소", example = "서울 송파구 신천동 29")
+    private String addressName;
+
 
     public static PlaceResponseDto from(KakaoApiResponseDto.Document document) {
         return new PlaceResponseDto(

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/service/PlaceService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/service/PlaceService.java
@@ -24,12 +24,8 @@ public class PlaceService {
     @Value("${kakao.api.key}")
     private String kakaoApiKey;
 
-    public List<PlaceResponseDto> searchPlaces(String query, String x, String y, Integer radius) {
+    public List<PlaceResponseDto> searchByKeyword(String query, String x, String y, Integer radius) {
         try {
-            log.info("Searching places with query: {}, x: {}, y: {}, radius: {}", query, x, y, radius);
-            log.info("Using Kakao API Key: {}", kakaoApiKey);
-            log.info("Authorization Header: KakaoAK {}", kakaoApiKey);
-
             KakaoApiResponseDto response = webClient.get()
                     .uri(uriBuilder -> {
                         URI uri = uriBuilder
@@ -37,16 +33,14 @@ public class PlaceService {
                                 .queryParam("query", query)
                                 .queryParam("x", x)
                                 .queryParam("y", y)
-                                .queryParam("radius", radius)
+                                .queryParam("radius", radius != null ? radius : 10000)
                                 .build();
-                        log.info("Request URI: {}", uri);
                         return uri;
                     })
                     .header("Authorization", "KakaoAK " + kakaoApiKey)
                     .header("Content-Type", "application/json;charset=UTF-8")
                     .retrieve()
-                    .bodyToMono(KakaoApiResponseDto.class) // 여기에서 DTO 클래스로 변환
-                    .doOnNext(body -> log.info("Kakao API response: {}", body))
+                    .bodyToMono(KakaoApiResponseDto.class)
                     .doOnError(error -> log.error("Kakao API Error: {}", error.getMessage()))
                     .block();
 
@@ -71,10 +65,6 @@ public class PlaceService {
             String y,
             Integer radius) {
         try {
-            log.info("Searching by category: {}, x: {}, y: {}, radius: {}", category_group_code, x, y, radius);
-            log.info("Using Kakao API Key: {}", kakaoApiKey);
-            log.info("Authorization Header: KakaoAK {}", kakaoApiKey);
-
             KakaoApiResponseDto response = webClient.get()
                     .uri(uriBuilder -> {
                         URI uri = uriBuilder
@@ -82,7 +72,7 @@ public class PlaceService {
                                 .queryParam("category_group_code", category_group_code)
                                 .queryParam("x", x)
                                 .queryParam("y", y)
-                                .queryParam("radius", radius != null ? radius : 1000)
+                                .queryParam("radius", radius != null ? radius : 10000)
                                 .build();
                         log.info("Request URI: {}", uri);
                         return uri;
@@ -91,11 +81,9 @@ public class PlaceService {
                     .header("Content-Type", "application/json;charset=UTF-8")
                     .retrieve()
                     .bodyToMono(KakaoApiResponseDto.class)
-                    .doOnNext(body -> log.info("Kakao API raw response: {}", body))
                     .doOnError(error -> log.error("Kakao API Error: {}", error.getMessage()))
                     .block();
 
-            log.info("Kakao API Response received");
 
             if (response != null && response.getDocuments() != null) {
                 return response.getDocuments().stream()


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #6

---
### 📌 요약
- 카카오맵 api 활용 검색 기능 api 구현했습니다
- 키워드 기반과 카테고리 기반 검색 모두 지원합니다.

### ✅ 작업 내용
- WebClient를 이용해 Kakao API 호출 로직 구현  
- 키워드 기반 검색 메서드 `searchByKeyword(...)` 추가  
- 카테고리 기반 검색 메서드 `searchByCategory(...)` 추가 

### 📚 참고 자료, 할 말
- API 테스트는 Postman으로 진행 완료 (200 OK 응답 확인)
- 카카오 로컬 API 문서 : https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-keyword 
