### PR TITLE
[FEATURE] 카카오 로그인 및 일반 유저 로그인/회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-web-services'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/goormton/backend/sodamsodam/domain/common/BaseEntity.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/common/BaseEntity.java
@@ -13,6 +13,10 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/goormton/backend/sodamsodam/domain/token/domain/RefreshToken.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/token/domain/RefreshToken.java
@@ -1,7 +1,8 @@
 package goormton.backend.sodamsodam.domain.token.domain;
 
-import goormton.backend.sodamsodam.domain.common.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken extends BaseEntity {
+public class RefreshToken {
 
     @Id
     private String refreshToken;

--- a/src/main/java/goormton/backend/sodamsodam/domain/token/domain/RefreshToken.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/token/domain/RefreshToken.java
@@ -1,0 +1,31 @@
+package goormton.backend.sodamsodam.domain.token.domain;
+
+import goormton.backend.sodamsodam.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    private LocalDateTime expiryDate;
+
+    @Builder
+    public RefreshToken(String refreshToken, Long userId, LocalDateTime expiryDate) {
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/token/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/token/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package goormton.backend.sodamsodam.domain.token.domain.repository;
+
+import goormton.backend.sodamsodam.domain.token.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/application/CustomUserDetailService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/application/CustomUserDetailService.java
@@ -1,0 +1,25 @@
+package goormton.backend.sodamsodam.domain.user.application;
+
+import goormton.backend.sodamsodam.domain.user.domain.User;
+import goormton.backend.sodamsodam.domain.user.domain.UserPrincipal;
+import goormton.backend.sodamsodam.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다. ID: " + username));
+
+        return new UserPrincipal(user);
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/application/UserService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/application/UserService.java
@@ -1,4 +1,19 @@
 package goormton.backend.sodamsodam.domain.user.application;
 
+import goormton.backend.sodamsodam.domain.user.domain.User;
+import goormton.backend.sodamsodam.domain.user.dto.request.LoginRequest;
+import goormton.backend.sodamsodam.domain.user.dto.request.SignupRequest;
+import goormton.backend.sodamsodam.domain.user.dto.response.JwtResponse;
+
 public interface UserService {
+
+    public void addUser(SignupRequest request);
+
+    public JwtResponse signupAndLogin(SignupRequest request);
+
+    public JwtResponse loginAndGetToken(LoginRequest request);
+
+    public User getUser(Long id);
+
+    public boolean verifyCurrentPassword(User user, String rawPassword);
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/application/UserService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/application/UserService.java
@@ -1,0 +1,4 @@
+package goormton.backend.sodamsodam.domain.user.application;
+
+public interface UserService {
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/application/UserServiceImpl.java
@@ -1,0 +1,80 @@
+package goormton.backend.sodamsodam.domain.user.application;
+
+import goormton.backend.sodamsodam.domain.user.domain.User;
+import goormton.backend.sodamsodam.domain.user.domain.UserRole;
+import goormton.backend.sodamsodam.domain.user.domain.repository.UserRepository;
+import goormton.backend.sodamsodam.domain.user.dto.request.LoginRequest;
+import goormton.backend.sodamsodam.domain.user.dto.request.SignupRequest;
+import goormton.backend.sodamsodam.domain.user.dto.response.JwtResponse;
+import goormton.backend.sodamsodam.global.error.DefaultException;
+import goormton.backend.sodamsodam.global.payload.ErrorCode;
+import goormton.backend.sodamsodam.global.util.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void addUser(SignupRequest request) {
+        User user = User.builder()
+                .username(request.username())
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .role(UserRole.USER)
+                .build();
+
+        userRepository.save(user);
+    }
+
+    public JwtResponse signupAndLogin(SignupRequest request) {
+        addUser(request);
+
+        return loginAndGetToken(new LoginRequest(request.username(), request.email(), request.password()));
+    }
+
+    public JwtResponse loginAndGetToken(LoginRequest request) {
+        System.out.println(request.username());
+        System.out.println(request.password());
+//        사용자 인증
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.username(), request.password())
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+//        jwt 생성
+        User user = userRepository.findByUsername(request.username()).orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다: " + request.username()));
+        String jwt = jwtUtil.generateToken(user.getId(), user.getUsername(), user.getEmail(), user.getRole().toString());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getId());
+
+        return new JwtResponse(jwt, refreshToken, "Bearer");
+    }
+
+    public User getUser(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new DefaultException(ErrorCode.INVALID_PARAMETER));
+    }
+
+    public void deleteUser(Long id) {
+        User user = getUser(id);
+        userRepository.delete(user);
+    }
+
+    public boolean verifyCurrentPassword(User user, String rawPassword) {
+        return passwordEncoder.matches(rawPassword, user.getPassword());
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/application/oauth/PrincipalOauth2UserService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/application/oauth/PrincipalOauth2UserService.java
@@ -6,8 +6,6 @@ import goormton.backend.sodamsodam.domain.user.domain.UserRole;
 import goormton.backend.sodamsodam.domain.user.domain.oauth.KakaoUserInfo;
 import goormton.backend.sodamsodam.domain.user.domain.oauth.OAuth2UserInfo;
 import goormton.backend.sodamsodam.domain.user.domain.repository.UserRepository;
-import goormton.backend.sodamsodam.global.error.DefaultExeption;
-import goormton.backend.sodamsodam.global.payload.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -25,7 +23,7 @@ import java.util.Optional;
 public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
+//    private final PasswordEncoder passwordEncoder;
 
     // 구글로 부터 받은 userRequest에 대한 후처리 함수
     // 함수 종료시 @AuthenticationPrincipal 어노테이션이 만들어짐.

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/application/oauth/PrincipalOauth2UserService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/application/oauth/PrincipalOauth2UserService.java
@@ -1,0 +1,69 @@
+package goormton.backend.sodamsodam.domain.user.application.oauth;
+
+import goormton.backend.sodamsodam.domain.user.domain.User;
+import goormton.backend.sodamsodam.domain.user.domain.UserPrincipal;
+import goormton.backend.sodamsodam.domain.user.domain.UserRole;
+import goormton.backend.sodamsodam.domain.user.domain.repository.UserRepository;
+import goormton.backend.sodamsodam.global.error.DefaultExeption;
+import goormton.backend.sodamsodam.global.payload.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 구글로 부터 받은 userRequest에 대한 후처리 함수
+    // 함수 종료시 @AuthenticationPrincipal 어노테이션이 만들어짐.
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("userRequest.clientRegistration : {}",userRequest.getClientRegistration());
+        log.info("userRequest.access_Token : {}",userRequest.getAccessToken());
+        log.info("userRequest.access_Token.Token_value  : {}",userRequest.getAccessToken().getTokenValue());
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        // 위 request 정보를 토대로 강제 회원가입 진행
+        // 구글로그인버튼 -> 구글로그인 창 -> 로그인 완료 -> 사용자 정보 code를 리턴 받음(userRequest에 담김) -> code를 토대로 Access Token 요청
+        //
+        // userRequest 정보를 토대로
+        // -> 회원 프로필을 받아야함 (loadUser 함수) -> 구글로부터 회원 프로필을 받아줌
+        log.info("userRequest.getAttributes : {}", super.loadUser(userRequest).getAttributes());
+
+        // kakao
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        String provider_id = oAuth2User.getAttribute("id"); // provid
+
+        String email = oAuth2User.getAttribute("email");
+        String username = provider + provider_id; // google_sub
+        String password = passwordEncoder.encode("getInthere");
+        UserRole role = UserRole.USER;
+
+        User userEntity = userRepository.findByEmail(email).orElseThrow(() -> new DefaultExeption(ErrorCode.USER_NOT_FOUND_ERROR));
+
+        if (userEntity == null) {
+            userEntity = User.builder()
+                    .username(username)
+                    .email(email)
+                    .password(password)
+                    .provider(provider)
+                    .provider_id(provider_id)
+                    .role(role)
+                    .build();
+            userRepository.save(userEntity);
+        } else {
+            log.info("최초 로그인이 아닙니다.");
+        }
+        return new UserPrincipal(userEntity, oAuth2User.getAttributes());
+    }
+
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/User.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/User.java
@@ -31,16 +31,16 @@ public class User extends BaseEntity {
     private UserRole role;
 
     private String provider;
-    private String provider_id;
+    private String providerId;
 
     @Builder(toBuilder = true)
-    User(String username, String email, String password, String profile_picture, UserRole role, String provider, String provider_id) {
+    User(String username, String email, String password, String profile_picture, UserRole role, String provider, String providerId) {
         this.username = username;
         this.email = email;
         this.password = password;
         this.profile_picture = profile_picture;
         this.role = role;
         this.provider = provider;
-        this.provider_id = provider_id;
+        this.providerId = providerId;
     }
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/User.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/User.java
@@ -1,0 +1,46 @@
+package goormton.backend.sodamsodam.domain.user.domain;
+
+import goormton.backend.sodamsodam.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String profile_picture;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    private String provider;
+    private String provider_id;
+
+    @Builder(toBuilder = true)
+    User(String username, String email, String password, String profile_picture, UserRole role, String provider, String provider_id) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.profile_picture = profile_picture;
+        this.role = role;
+        this.provider = provider;
+        this.provider_id = provider_id;
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/User.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/User.java
@@ -12,10 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     @Column(unique = true, nullable = false)
     private String username;
 

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserPrincipal.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserPrincipal.java
@@ -1,0 +1,85 @@
+package goormton.backend.sodamsodam.domain.user.domain;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+public class UserPrincipal implements UserDetails, OAuth2User {
+
+    private User user;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public UserPrincipal(User user, Collection<? extends GrantedAuthority> authorities) {
+        this.user = user;
+        this.authorities = authorities;
+    }
+
+    public UserPrincipal(User user) {
+        this.user = user;
+        this.authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
+    }
+
+    public UserPrincipal(User user,
+                         Collection<? extends GrantedAuthority> authorities,
+                         Map<String, Object> attributes) {
+        this.user = user;
+        this.authorities = authorities;
+        this.attributes = attributes;
+    }
+
+    public UserPrincipal(User user,
+                         Map<String, Object> attributes) {
+        this.user = user;
+        this.authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    // 아이디에 해당하는 username을 email로 사용
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getEmail());
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserPrincipal.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserPrincipal.java
@@ -45,7 +45,7 @@ public class UserPrincipal implements UserDetails, OAuth2User {
 
     @Override
     public String getPassword() {
-        return null;
+        return user.getPassword();
     }
 
     // 아이디에 해당하는 username을 email로 사용

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserPrincipal.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserPrincipal.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -61,6 +62,15 @@ public class UserPrincipal implements UserDetails, OAuth2User {
     @Override
     public Map<String, Object> getAttributes() {
         return attributes;
+    }
+
+    // 해당 User의 권한을 리턴하는 곳
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(
+                (GrantedAuthority) () -> String.valueOf(user.getRole()));
+        return collection;
     }
 
     @Override

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserRole.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/UserRole.java
@@ -1,0 +1,13 @@
+package goormton.backend.sodamsodam.domain.user.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER");
+
+    private final String value;
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/oauth/KakaoUserInfo.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/oauth/KakaoUserInfo.java
@@ -1,0 +1,32 @@
+package goormton.backend.sodamsodam.domain.user.domain.oauth;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuth2UserInfo{
+
+    private Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("id").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("account_email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("profile_nickname");
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/oauth/OAuth2UserInfo.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/oauth/OAuth2UserInfo.java
@@ -1,0 +1,9 @@
+package goormton.backend.sodamsodam.domain.user.domain.oauth;
+
+// OAuth2.0 제공자들 마다 응답해주는 속성값이 달라서 공통으로 만들어준다.
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package goormton.backend.sodamsodam.domain.user.domain.repository;
+
+import goormton.backend.sodamsodam.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/domain/repository/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/dto/request/LoginRequest.java
@@ -1,6 +1,7 @@
 package goormton.backend.sodamsodam.domain.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -9,6 +10,9 @@ public record LoginRequest(
         @NotBlank(message = "아이디는 필수입니다.")
         @Size(min = 3, max = 10, message = "아이디는 3 ~ 13글자여야 합니다.")
         String username,
+
+        @Email
+        String email,
 
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Size(min = 8, max = 15, message = "비밀번호는 8 ~ 15글자여야 합니다.")

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,17 @@
+package goormton.backend.sodamsodam.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "유저 로그인용 request DTO입니다.")
+public record LoginRequest(
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Size(min = 3, max = 10, message = "아이디는 3 ~ 13글자여야 합니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8 ~ 15글자여야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/dto/request/SignupRequest.java
@@ -1,0 +1,21 @@
+package goormton.backend.sodamsodam.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "유저 회원가입용 requestDTO입니다.")
+public record SignupRequest(
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Size(min = 3, max = 10, message = "아이디는 3 ~ 13글자여야 합니다.")
+        String username,
+
+        @Email
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 15, message = "비밀번호는 8 ~ 15글자여야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/dto/response/JwtResponse.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/dto/response/JwtResponse.java
@@ -1,0 +1,11 @@
+package goormton.backend.sodamsodam.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "jwt 토큰이 반환되는 responseDTO입니다.")
+public record JwtResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType
+) {
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,13 @@
+package goormton.backend.sodamsodam.domain.user.dto.response;
+
+import goormton.backend.sodamsodam.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 정보 조회용 response DTO입니다.")
+public record UserInfoResponse(
+        String email
+) {
+    public static UserInfoResponse fromEntity(User user) {
+        return new UserInfoResponse(user.getEmail());
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/user/presentation/AuthController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/user/presentation/AuthController.java
@@ -1,0 +1,55 @@
+package goormton.backend.sodamsodam.domain.user.presentation;
+
+import goormton.backend.sodamsodam.domain.user.application.UserService;
+import goormton.backend.sodamsodam.domain.user.application.UserServiceImpl;
+import goormton.backend.sodamsodam.domain.user.dto.request.LoginRequest;
+import goormton.backend.sodamsodam.domain.user.dto.request.SignupRequest;
+import goormton.backend.sodamsodam.domain.user.dto.response.JwtResponse;
+import goormton.backend.sodamsodam.global.payload.ResponseCustom;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "권한 인증 API", description = "유저 로그인 및 회원가입에 대한 API입니다.")
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+public class AuthController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원가입 후 로그인", description = "회원가입과 로그인을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = JwtResponse.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "실패")
+    })
+    @PostMapping("/signup")
+    public ResponseCustom<?> signupUser(@Valid @RequestBody SignupRequest request) {
+        JwtResponse response = userService.signupAndLogin(request);
+        return ResponseCustom.CREATED(response);
+    }
+
+    @Operation(summary = "유저 로그인", description = "로그인을 수행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = JwtResponse.class))
+            }),
+            @ApiResponse(responseCode = "400", description = "실패")
+    })
+    @PostMapping("/login")
+    public ResponseCustom<?> loginUser(@Valid @RequestBody LoginRequest request) {
+        JwtResponse response = userService.loginAndGetToken(request);
+        return ResponseCustom.OK(response);
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/global/config/SwaggerConfig.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/config/SwaggerConfig.java
@@ -2,8 +2,7 @@ package goormton.backend.sodamsodam.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,11 +23,30 @@ public class SwaggerConfig {
                 .in(SecurityScheme.In.HEADER)
                 .name("Authorization");
 
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
+        // Kakao OAuth2 인증 스킴
+        SecurityScheme oauthScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.OAUTH2)
+                .description("Kakao OAuth2 flow for obtaining access token")
+                .flows(new OAuthFlows()
+                        .authorizationCode(new OAuthFlow()
+                                .authorizationUrl("https://kauth.kakao.com/oauth/authorize")
+                                .tokenUrl("https://kauth.kakao.com/oauth/token")
+                                .scopes(new Scopes()
+                                        .addString("account_email", "이메일 조회 권한")
+                                        .addString("profile_nickname", "프로필 닉네임 조회 권한")
+                                )
+                        )
+                );
+
+        // 보안 요구사항 설정: JWT 또는 OAuth2
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("BearerAuth")
+                .addList("KakaoOAuth");
 
         return new OpenAPI()
                 .info(info)
                 .addSecurityItem(securityRequirement)
-                .schemaRequirement("BearerAuth", securityScheme);
+                .schemaRequirement("BearerAuth", securityScheme)
+                .schemaRequirement("KakaoOAuth", oauthScheme);
     }
 }

--- a/src/main/java/goormton/backend/sodamsodam/global/config/security/SecurityConfig.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/config/security/SecurityConfig.java
@@ -1,7 +1,9 @@
 package goormton.backend.sodamsodam.global.config.security;
 
+import goormton.backend.sodamsodam.domain.user.application.oauth.PrincipalOauth2UserService;
 import goormton.backend.sodamsodam.global.util.jwt.JWTAuthenticationFilter;
 import goormton.backend.sodamsodam.global.util.jwt.JwtUtil;
+import goormton.backend.sodamsodam.global.util.jwt.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +19,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -28,6 +31,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsService userDetailsService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     private static final String[] AUTH_WHITELIST = {
             "/swagger-ui/**",
@@ -39,7 +43,7 @@ public class SecurityConfig {
     };
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, PrincipalOauth2UserService principalOauth2UserService) throws Exception {
         JWTAuthenticationFilter jwtFilter = new JWTAuthenticationFilter(jwtUtil, userDetailsService);
 
         http
@@ -69,6 +73,12 @@ public class SecurityConfig {
                 )
 //                jwt 필터 설정
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+//                kakao 로그인 설정
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(u -> u
+                                .userService(principalOauth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                )
 //                로그아웃 설정 추가
 //                .logout(logout -> logout
 //                        .logoutUrl("/api/auth/logout")

--- a/src/main/java/goormton/backend/sodamsodam/global/config/security/SecurityConfig.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/config/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package goormton.backend.sodamsodam.global.config.security;
 
+import goormton.backend.sodamsodam.global.util.jwt.JWTAuthenticationFilter;
+import goormton.backend.sodamsodam.global.util.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -12,16 +14,20 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableAutoConfiguration
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
 
     private static final String[] AUTH_WHITELIST = {
             "/swagger-ui/**",
@@ -34,7 +40,7 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-//        JwtFilter jwtFilter = new JwtFilter(jwtUtil, userDetailsService);
+        JWTAuthenticationFilter jwtFilter = new JWTAuthenticationFilter(jwtUtil, userDetailsService);
 
         http
 //                cors 설정
@@ -61,10 +67,8 @@ public class SecurityConfig {
 //                                혹시 모를 다른 모든 요청 역시 인증 필요
                                 .anyRequest().authenticated()
                 )
-                // oauth 로그인 후처리
-
 //                jwt 필터 설정
-//                .addFilterBefore(jwtFilter, BasicAuthenticationFilter.class)
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 //                로그아웃 설정 추가
 //                .logout(logout -> logout
 //                        .logoutUrl("/api/auth/logout")

--- a/src/main/java/goormton/backend/sodamsodam/global/config/security/SecurityConfig.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/config/security/SecurityConfig.java
@@ -1,0 +1,87 @@
+package goormton.backend.sodamsodam.global.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableAutoConfiguration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private static final String[] AUTH_WHITELIST = {
+            "/swagger-ui/**",
+            "/api-docs",
+            "/swagger-ui-custom.html",
+            "/v3/api-docs/**",
+            "/api-docs/**",
+            "/swagger-ui.html"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        JwtFilter jwtFilter = new JwtFilter(jwtUtil, userDetailsService);
+
+        http
+//                cors 설정
+                .cors(Customizer.withDefaults())
+//                crsf disable
+                .csrf(AbstractHttpConfigurer::disable)
+//                Form 로그인 방식 disable
+                .formLogin(AbstractHttpConfigurer::disable)
+//                Http Basic 인증 방식 disable
+                .httpBasic(AbstractHttpConfigurer::disable)
+//                세션 설정: STATELESS
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                경로별 인가 작업
+                .authorizeHttpRequests((auth) -> auth
+//                              미리 정의된 whitelist 경로는 모두 허용
+                                .requestMatchers(AUTH_WHITELIST).permitAll()
+//                              모든 get method는 허용
+                                .requestMatchers(HttpMethod.GET, "/**").permitAll()
+//                              유저 인증용 post method는 인증 없이 허용
+                                .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
+//                              그 외의 모든 post method는 인증 필요
+                                .requestMatchers(HttpMethod.POST, "/**").authenticated()
+//                                혹시 모를 다른 모든 요청 역시 인증 필요
+                                .anyRequest().authenticated()
+                )
+                // oauth 로그인 후처리
+
+//                jwt 필터 설정
+//                .addFilterBefore(jwtFilter, BasicAuthenticationFilter.class)
+//                로그아웃 설정 추가
+//                .logout(logout -> logout
+//                        .logoutUrl("/api/auth/logout")
+//                        .invalidateHttpSession(true)
+//                )
+        ;
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/global/error/DefaultException.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/error/DefaultException.java
@@ -4,16 +4,16 @@ import goormton.backend.sodamsodam.global.payload.ErrorCode;
 import lombok.Getter;
 
 @Getter
-public class DefaultExeption extends RuntimeException {
+public class DefaultException extends RuntimeException {
 
     private ErrorCode errorCode;
 
-    public DefaultExeption(ErrorCode errorCode) {
+    public DefaultException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 
-    public DefaultExeption(ErrorCode errorCode, String message) {
+    public DefaultException(ErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
     }

--- a/src/main/java/goormton/backend/sodamsodam/global/error/ExceptionHandlerAdvice.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/error/ExceptionHandlerAdvice.java
@@ -64,8 +64,8 @@ public class ExceptionHandlerAdvice {
         return new ResponseEntity<>(apiResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    @ExceptionHandler(DefaultExeption.class)
-    protected ResponseEntity<?> handleDefaultExeption(DefaultExeption e) {
+    @ExceptionHandler(DefaultException.class)
+    protected ResponseEntity<?> handleDefaultExeption(DefaultException e) {
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponse response = ErrorResponse.builder()
                 .httpStatus(errorCode.getHttpStatus())

--- a/src/main/java/goormton/backend/sodamsodam/global/error/InvalidParameterException.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/error/InvalidParameterException.java
@@ -8,7 +8,7 @@ import org.springframework.validation.FieldError;
 import java.util.List;
 
 @Getter
-public class InvalidParameterException extends DefaultExeption{
+public class InvalidParameterException extends DefaultException{
 
     private Errors errors;
 

--- a/src/main/java/goormton/backend/sodamsodam/global/util/jwt/JWTAuthenticationFilter.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/util/jwt/JWTAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package goormton.backend.sodamsodam.global.util.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JWTAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwt = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(jwt) && jwtUtil.validateToken(jwt)) {
+                String username = jwtUtil.getUsernameFromToken(jwt);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        } catch (ExpiredJwtException e) {
+            log.error("Access token expired: {}", e.getMessage());
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            PrintWriter writer = response.getWriter();
+            writer.print("Access token expired");
+            return;
+        } catch (Exception e) {
+            log.error("Invalid access Token: {}", e.getMessage());
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            PrintWriter writer = response.getWriter();
+            writer.print("Invalid access token");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            log.debug("bearerToken = {}", bearerToken.substring(7, bearerToken.length()));
+            return bearerToken.substring(7, bearerToken.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/global/util/jwt/JwtUtil.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/util/jwt/JwtUtil.java
@@ -49,11 +49,11 @@ public class JwtUtil {
     }
 
 //    jwt로부터 정보 추출
-    public Long getIdFromRefreshToken(String token) {
+    public Long getIdFromToken(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
     }
 
-    public String getUsernameFromRefreshToken(String token) {
+    public String getUsernameFromToken(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
     }
 
@@ -62,8 +62,8 @@ public class JwtUtil {
     }
 
 //    jwt 유효성 검증
-    public Boolean validateRefreshToken(String token) {
-        final String username = getUsernameFromRefreshToken(token);
+    public Boolean validateToken(String token) {
+        final String username = getUsernameFromToken(token);
         return (!isTokenExpired(token));
     }
 

--- a/src/main/java/goormton/backend/sodamsodam/global/util/jwt/JwtUtil.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/util/jwt/JwtUtil.java
@@ -1,0 +1,74 @@
+package goormton.backend.sodamsodam.global.util.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long jwtExpirationInMs;
+    private final long refreshTokenExpirationInMs;
+
+    public JwtUtil(@Value("${app.auth.token-secret}") String secretKey,
+                   @Value("${app.auth.access-token-expiration-msec}") long jwtExpirationInMs,
+                   @Value("${app.auth.refresh-token-expiration-msec}") long refreshTokenExpirationInMs) {
+
+        this.secretKey = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.jwtExpirationInMs = jwtExpirationInMs;
+        this.refreshTokenExpirationInMs = refreshTokenExpirationInMs;
+    }
+
+//    Jwt 토큰 생성
+    public String generateToken(Long userId, String username, String email, String role) {
+
+        return Jwts.builder()
+                .claim("userId", userId)
+                .claim("username", username)
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + jwtExpirationInMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .claim("userId", userId)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpirationInMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+//    jwt로부터 정보 추출
+    public Long getIdFromRefreshToken(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
+    }
+
+    public String getUsernameFromRefreshToken(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRoleFromToken(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+//    jwt 유효성 검증
+    public Boolean validateRefreshToken(String token) {
+        final String username = getUsernameFromRefreshToken(token);
+        return (!isTokenExpired(token));
+    }
+
+//    jwt 토큰 만료 여부 확인
+    public Boolean isTokenExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+}

--- a/src/main/java/goormton/backend/sodamsodam/global/util/jwt/OAuth2SuccessHandler.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/util/jwt/OAuth2SuccessHandler.java
@@ -1,0 +1,49 @@
+package goormton.backend.sodamsodam.global.util.jwt;
+
+import goormton.backend.sodamsodam.domain.token.domain.RefreshToken;
+import goormton.backend.sodamsodam.domain.token.domain.repository.RefreshTokenRepository;
+import goormton.backend.sodamsodam.domain.user.domain.UserPrincipal;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        String accessToken = jwtUtil.generateToken(
+                userPrincipal.getUser().getId(),
+                userPrincipal.getUsername(),
+                userPrincipal.getUser().getEmail(),
+                userPrincipal.getUser().getRole().getValue()
+        );
+
+        String refreshToken = jwtUtil.generateRefreshToken(userPrincipal.getUser().getId());
+
+        // DB에 Refresh Token 저장
+        RefreshToken token = RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .userId(userPrincipal.getUser().getId())
+                .expiryDate(LocalDateTime.now().plusDays(7))
+                .build();
+
+        refreshTokenRepository.save(token);
+
+        // 프론트엔드에 전달
+        response.sendRedirect("http://localhost:3000/oauth2/redirect?accessToken=" + accessToken + "&refreshToken=" + refreshToken);
+    }
+}


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #4

---
### 📌 요약
- oauth2를 이용해 유저 로그인 구현

### ✅ 작업 내용
- 폼로그인으로 기본 유저 로그인/회원가입 구현
- kakao 간편 로그인을 통해 유저 로그인 기능 구현
- 일단 security config 설정은 get은 인증 없이, post는 로그인/회원가

### 📚 참고 자료, 할 말
- oauth2 로그인을 간편한 hadler로 구현했기 때문에, login url을 https://kauth.kakao.com/oauth/authorize 로 지정하고 redirect url을 http://54.180.248.100/oauth 로 지정해야함
