### PR TITLE
[CHORE] 임시 User 엔티티 제거 및 리뷰 서비스 로직 정비

### DIFF
--- a/src/main/java/goormton/backend/sodamsodam/domain/place/entity/Search.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/entity/Search.java
@@ -1,6 +1,6 @@
 package goormton.backend.sodamsodam.domain.place.entity;
 
-import goormton.backend.sodamsodam.domain.user.entity.User;
+import goormton.backend.sodamsodam.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/repository/SearchRepository.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/repository/SearchRepository.java
@@ -2,7 +2,7 @@ package goormton.backend.sodamsodam.domain.place.repository;
 
 import goormton.backend.sodamsodam.domain.place.entity.Search;
 import org.springframework.data.jpa.repository.JpaRepository;
-import goormton.backend.sodamsodam.domain.user.entity.User;
+import goormton.backend.sodamsodam.domain.user.domain.User;
 import java.util.List;
 
 public interface SearchRepository extends JpaRepository<Search, Long> {

--- a/src/main/java/goormton/backend/sodamsodam/domain/place/service/PlaceService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/service/PlaceService.java
@@ -5,7 +5,7 @@ import goormton.backend.sodamsodam.domain.place.dto.PlaceResponseDto;
 import goormton.backend.sodamsodam.domain.place.entity.Search;
 import goormton.backend.sodamsodam.domain.place.repository.SearchRepository;
 import goormton.backend.sodamsodam.domain.place.dto.SearchHistoryDto;
-import goormton.backend.sodamsodam.domain.user.entity.User;
+import goormton.backend.sodamsodam.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/entity/Review.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/entity/Review.java
@@ -2,7 +2,7 @@ package goormton.backend.sodamsodam.domain.review.entity;
 
 import goormton.backend.sodamsodam.domain.common.BaseEntity;
 import goormton.backend.sodamsodam.domain.review.enums.ReviewTag;
-import goormton.backend.sodamsodam.domain.user.entity.User;
+import goormton.backend.sodamsodam.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/service/ReviewService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/service/ReviewService.java
@@ -6,9 +6,9 @@ import goormton.backend.sodamsodam.domain.review.entity.Review;
 import goormton.backend.sodamsodam.domain.review.enums.ReviewTag;
 import goormton.backend.sodamsodam.domain.review.repository.ImageRepository;
 import goormton.backend.sodamsodam.domain.review.repository.ReviewRepository;
-import goormton.backend.sodamsodam.domain.user.entity.User;
-import goormton.backend.sodamsodam.domain.user.repository.UserRepository;
-import goormton.backend.sodamsodam.global.error.DefaultExeption;
+import goormton.backend.sodamsodam.domain.user.domain.User;
+import goormton.backend.sodamsodam.domain.user.domain.repository.UserRepository;
+import goormton.backend.sodamsodam.global.error.DefaultException;
 import goormton.backend.sodamsodam.global.payload.ErrorCode;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,7 +29,7 @@ public class ReviewService {
 
     public ReviewCreateResponseDto createReview(Long userId, String placeId, ReviewCreateRequestDto dto) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new DefaultExeption(ErrorCode.USER_NOT_FOUND_ERROR));
+                .orElseThrow(() -> new DefaultException(ErrorCode.USER_NOT_FOUND_ERROR));
 
         Review review = Review.builder()
                 .user(user)
@@ -58,7 +58,7 @@ public class ReviewService {
         Page<Review> reviewPage = reviewRepository.findAllByPlaceIdWithUser(placeId, pageable);
 
         List<ReviewResponseDto> reviewDtos = reviewPage.map(review -> {
-            String username = review.getUser().getName();
+            String username = review.getUser().getUsername();
             List<String> imageUrls=imageRepository.findUrlsByReviewId(review.getId());
             return ReviewResponseDto.from(review, username, imageUrls);
         }).getContent();
@@ -76,10 +76,10 @@ public class ReviewService {
     @Transactional
     public void updateReview(Long userId, Long reviewId, ReviewUpdateRequestDto dto) {
         Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new DefaultExeption(ErrorCode.REVIEW_NOT_FOUND_ERROR));
+                .orElseThrow(() -> new DefaultException(ErrorCode.REVIEW_NOT_FOUND_ERROR));
 
         if (!review.getUser().getId().equals(userId)) {
-            throw new DefaultExeption(ErrorCode.FORBIDDEN_REVIEW_UPDATE);
+            throw new DefaultException(ErrorCode.FORBIDDEN_REVIEW_UPDATE);
         }
 
         List<ReviewTag> tags = dto.getTags();
@@ -112,7 +112,7 @@ public class ReviewService {
 
         Set<ReviewTag> tagSet = new HashSet<>(tags);
         if (tagSet.size() != tags.size()) {
-            throw new DefaultExeption(ErrorCode.DUPLICATE_REVIEW_TAGS);
+            throw new DefaultException(ErrorCode.DUPLICATE_REVIEW_TAGS);
         }
     }
 }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #25 

---
### 📌 요약
- place, review 패키지에서 임시로 사용하던 User 엔티티 제거 후 진짜 User 엔티티로 교체

### ✅ 작업 내용
- 임시 User 엔티티(로컬에서만 사용했습니다. 깃허브엔 푸시 안 했습니다.) 제거 및 실제 엔티티 적용
- ReviewService 내 DefaultException 오타 수정 (DefaultExeption → DefaultException)
- ReviewService 내 61번 라인 리뷰 작성자 이름 반환 시 getName() → getUsername()으로 수정

### 📚 참고 자료, 할 말
-
