### PR TITLE
[FEATURE] 내 리뷰 단건 조회 구현

### DIFF
--- a/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/")
+@RequestMapping("/api")
 @Tag(name = "리뷰", description = "리뷰 관련 API")
 
 public class ReviewController {
@@ -40,7 +40,7 @@ public class ReviewController {
 
 
     @Operation(summary = "장소 리뷰 목록 조회",description = "특정 장소에 달린 모든 리뷰를 최신순으로 가져옵니다. ")
-    @GetMapping("places/{placeId}/reviews")
+    @GetMapping("/places/{placeId}/reviews")
     public ResponseCustom<PlaceReviewListResponseDto> getPlaceReviews(
             @PathVariable String placeId,
             @Parameter(hidden = true) @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -50,7 +50,7 @@ public class ReviewController {
     }
 
     @Operation(summary = "리뷰 수정",description = "본인이 작성한 리뷰의 내용을 수정합니다.")
-    @PatchMapping("reviews/{reviewId}")
+    @PatchMapping("/reviews/{reviewId}")
     public ResponseCustom<Void> updateReview(
             @Parameter(description = "AccessToken을 입력해주세요", required = true)
             @RequestHeader("Authorization") String token,
@@ -64,7 +64,7 @@ public class ReviewController {
     }
 
     @Operation(summary = "리뷰 삭제",description = "본인이 작성한 리뷰를 삭제합니다.")
-    @DeleteMapping("reviews/{reviewId}")
+    @DeleteMapping("/reviews/{reviewId}")
     public ResponseCustom<Void> deleteReview(
             @Parameter(description = "AccessToken을 입력해주세요", required = true)
             @RequestHeader("Authorization") String token,
@@ -82,7 +82,7 @@ public class ReviewController {
             @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님"),
             @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
     })
-    @GetMapping("reviews/{reviewId}")
+    @GetMapping("/reviews/{reviewId}")
     public ResponseCustom<ReviewEditResponseDto> getReviewForEdit(
             @Parameter(description = "AccessToken을 입력해주세요", required = true)
             @RequestHeader("Authorization") String token,

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
@@ -5,13 +5,14 @@ import goormton.backend.sodamsodam.domain.review.service.ReviewService;
 import goormton.backend.sodamsodam.global.payload.ResponseCustom;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -65,5 +66,21 @@ public class ReviewController {
     ){
         reviewService.deleteReview(userId, reviewId);
         return ResponseCustom.OK();
+    }
+
+    @Operation(summary = "본인 리뷰 단건 조회", description = "리뷰 수정 전, 본인이 작성한 리뷰의 내용을 불러옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "본인이 작성한 리뷰가 아님"),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음")
+    })
+    @GetMapping("reviews/{reviewId}")
+    public ResponseCustom<ReviewEditResponseDto> getReviewForEdit(
+            //@AuthenticationPrincipal(expression = "userId") Long userId, TODO: JWT 인증 연동 후 해제
+            @RequestHeader("X-USER-ID") Long userId,
+            @PathVariable Long reviewId
+    ) {
+        ReviewEditResponseDto responseDto = reviewService.getReviewForEdit(userId, reviewId);
+        return ResponseCustom.OK(responseDto);
     }
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package goormton.backend.sodamsodam.domain.review.controller;
 import goormton.backend.sodamsodam.domain.review.dto.*;
 import goormton.backend.sodamsodam.domain.review.service.ReviewService;
 import goormton.backend.sodamsodam.global.payload.ResponseCustom;
+import goormton.backend.sodamsodam.global.util.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -22,15 +23,18 @@ import org.springframework.web.bind.annotation.*;
 
 public class ReviewController {
     private final ReviewService reviewService;
+    private final JwtUtil jwtUtil;
 
     @Operation(summary = "리뷰 작성",description = "특정 장소에 대한 리뷰를 작성합니다.")
     @PostMapping("places/{placeId}/reviews")
     public ResponseCustom<ReviewCreateResponseDto> createReview(
-            //@AuthenticationPrincipal(expression = "userId") Long userId, TODO: JWT 인증 연동 후 해제
-            @RequestHeader("X-USER-ID") Long userId,
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable String placeId,
             @Valid @RequestBody ReviewCreateRequestDto requestDto
     ) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long userId = jwtUtil.getIdFromToken(token);
+
         ReviewCreateResponseDto responseDto = reviewService.createReview(userId, placeId, requestDto);
         return ResponseCustom.CREATED(responseDto);
     }
@@ -48,11 +52,13 @@ public class ReviewController {
     @Operation(summary = "리뷰 수정",description = "본인이 작성한 리뷰의 내용을 수정합니다.")
     @PatchMapping("reviews/{reviewId}")
     public ResponseCustom<Void> updateReview(
-            //@AuthenticationPrincipal(expression = "userId") Long userId, TODO: JWT 인증 연동 후 해제
-            @RequestHeader("X-USER-ID") Long userId,
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewUpdateRequestDto requestDto
-            ){
+    ){
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long userId = jwtUtil.getIdFromToken(token);
+
         reviewService.updateReview(userId, reviewId, requestDto);
         return ResponseCustom.OK();
     }
@@ -60,10 +66,12 @@ public class ReviewController {
     @Operation(summary = "리뷰 삭제",description = "본인이 작성한 리뷰를 삭제합니다.")
     @DeleteMapping("reviews/{reviewId}")
     public ResponseCustom<Void> deleteReview(
-            //@AuthenticationPrincipal(expression = "userId") Long userId, TODO: JWT 인증 연동 후 해제
-            @RequestHeader("X-USER-ID") Long userId,
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long reviewId
     ){
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long userId = jwtUtil.getIdFromToken(token);
+
         reviewService.deleteReview(userId, reviewId);
         return ResponseCustom.OK();
     }
@@ -76,10 +84,12 @@ public class ReviewController {
     })
     @GetMapping("reviews/{reviewId}")
     public ResponseCustom<ReviewEditResponseDto> getReviewForEdit(
-            //@AuthenticationPrincipal(expression = "userId") Long userId, TODO: JWT 인증 연동 후 해제
-            @RequestHeader("X-USER-ID") Long userId,
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long reviewId
     ) {
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long userId = jwtUtil.getIdFromToken(token);
+
         ReviewEditResponseDto responseDto = reviewService.getReviewForEdit(userId, reviewId);
         return ResponseCustom.OK(responseDto);
     }

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("")
+@RequestMapping("/api/")
 @Tag(name = "리뷰", description = "리뷰 관련 API")
 
 public class ReviewController {
     private final ReviewService reviewService;
 
     @Operation(summary = "리뷰 작성",description = "특정 장소에 대한 리뷰를 작성합니다.")
-    @PostMapping("/places/{placeId}/reviews")
+    @PostMapping("places/{placeId}/reviews")
     public ResponseCustom<ReviewCreateResponseDto> createReview(
             //@AuthenticationPrincipal(expression = "userId") Long userId, TODO: JWT 인증 연동 후 해제
             @RequestHeader("X-USER-ID") Long userId,
@@ -36,7 +36,7 @@ public class ReviewController {
     }
 
     @Operation(summary = "장소 리뷰 목록 조회",description = "특정 장소에 달린 모든 리뷰를 최신순으로 가져옵니다. ")
-    @GetMapping("/places/{placeId}/reviews")
+    @GetMapping("places/{placeId}/reviews")
     public ResponseCustom<PlaceReviewListResponseDto> getPlaceReviews(
             @PathVariable String placeId,
             @Parameter(hidden = true) @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/controller/ReviewController.java
@@ -25,19 +25,19 @@ public class ReviewController {
     private final ReviewService reviewService;
     private final JwtUtil jwtUtil;
 
-    @Operation(summary = "리뷰 작성",description = "특정 장소에 대한 리뷰를 작성합니다.")
-    @PostMapping("places/{placeId}/reviews")
+    @Operation(summary = "리뷰 작성", description = "로그인된 사용자가 특정 장소에 리뷰를 작성합니다.")
+    @PostMapping("/places/{placeId}/reviews")
     public ResponseCustom<ReviewCreateResponseDto> createReview(
-            @RequestHeader("Authorization") String authorizationHeader,
+            @Parameter(description = "AccessToken을 입력해주세요", required = true)
+            @RequestHeader("Authorization") String token,
             @PathVariable String placeId,
             @Valid @RequestBody ReviewCreateRequestDto requestDto
     ) {
-        String token = authorizationHeader.replace("Bearer ", "");
-        Long userId = jwtUtil.getIdFromToken(token);
-
+        Long userId = jwtUtil.getIdFromToken(token.replace("Bearer ", ""));
         ReviewCreateResponseDto responseDto = reviewService.createReview(userId, placeId, requestDto);
         return ResponseCustom.CREATED(responseDto);
     }
+
 
     @Operation(summary = "장소 리뷰 목록 조회",description = "특정 장소에 달린 모든 리뷰를 최신순으로 가져옵니다. ")
     @GetMapping("places/{placeId}/reviews")
@@ -52,12 +52,12 @@ public class ReviewController {
     @Operation(summary = "리뷰 수정",description = "본인이 작성한 리뷰의 내용을 수정합니다.")
     @PatchMapping("reviews/{reviewId}")
     public ResponseCustom<Void> updateReview(
-            @RequestHeader("Authorization") String authorizationHeader,
+            @Parameter(description = "AccessToken을 입력해주세요", required = true)
+            @RequestHeader("Authorization") String token,
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewUpdateRequestDto requestDto
     ){
-        String token = authorizationHeader.replace("Bearer ", "");
-        Long userId = jwtUtil.getIdFromToken(token);
+        Long userId = jwtUtil.getIdFromToken(token.replace("Bearer ", ""));
 
         reviewService.updateReview(userId, reviewId, requestDto);
         return ResponseCustom.OK();
@@ -66,11 +66,11 @@ public class ReviewController {
     @Operation(summary = "리뷰 삭제",description = "본인이 작성한 리뷰를 삭제합니다.")
     @DeleteMapping("reviews/{reviewId}")
     public ResponseCustom<Void> deleteReview(
-            @RequestHeader("Authorization") String authorizationHeader,
+            @Parameter(description = "AccessToken을 입력해주세요", required = true)
+            @RequestHeader("Authorization") String token,
             @PathVariable Long reviewId
     ){
-        String token = authorizationHeader.replace("Bearer ", "");
-        Long userId = jwtUtil.getIdFromToken(token);
+        Long userId = jwtUtil.getIdFromToken(token.replace("Bearer ", ""));
 
         reviewService.deleteReview(userId, reviewId);
         return ResponseCustom.OK();
@@ -84,11 +84,11 @@ public class ReviewController {
     })
     @GetMapping("reviews/{reviewId}")
     public ResponseCustom<ReviewEditResponseDto> getReviewForEdit(
-            @RequestHeader("Authorization") String authorizationHeader,
+            @Parameter(description = "AccessToken을 입력해주세요", required = true)
+            @RequestHeader("Authorization") String token,
             @PathVariable Long reviewId
     ) {
-        String token = authorizationHeader.replace("Bearer ", "");
-        Long userId = jwtUtil.getIdFromToken(token);
+        Long userId = jwtUtil.getIdFromToken(token.replace("Bearer ", ""));
 
         ReviewEditResponseDto responseDto = reviewService.getReviewForEdit(userId, reviewId);
         return ResponseCustom.OK(responseDto);

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/dto/ReviewEditResponseDto.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/dto/ReviewEditResponseDto.java
@@ -1,0 +1,25 @@
+package goormton.backend.sodamsodam.domain.review.dto;
+
+import goormton.backend.sodamsodam.domain.review.enums.ReviewTag;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "리뷰 수정 폼 조회 응답 DTO")
+public class ReviewEditResponseDto {
+
+    @Schema(description = "리뷰 본문 내용", example = "맛있어요.")
+    private String content;
+
+    @Schema(description = "리뷰 태그 목록 (최대 3개)")
+    private List<ReviewTag> tags;
+
+    @Schema(description = "이미지 URL 목록 (최대 3개)")
+    private List<String> imageUrls;
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/service/ReviewService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/service/ReviewService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -127,5 +128,28 @@ public class ReviewService {
         if (tagSet.size() != tags.size()) {
             throw new DefaultException(ErrorCode.DUPLICATE_REVIEW_TAGS);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewEditResponseDto getReviewForEdit(Long userId, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new DefaultException(ErrorCode.REVIEW_NOT_FOUND_ERROR));
+
+        if (!review.getUser().getId().equals(userId)) {
+            throw new DefaultException(ErrorCode.FORBIDDEN_REVIEW_UPDATE);
+        }
+
+        List<String> imageUrls = imageRepository.findUrlsByReviewId(reviewId);
+
+        List<ReviewTag> tags = new ArrayList<>();
+        if (review.getTag1() != null) tags.add(review.getTag1());
+        if (review.getTag2() != null) tags.add(review.getTag2());
+        if (review.getTag3() != null) tags.add(review.getTag3());
+
+        return ReviewEditResponseDto.builder()
+                .content(review.getContent())
+                .tags(tags)
+                .imageUrls(imageUrls)
+                .build();
     }
 }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #27 

---
### 📌 요약
- 본인이 작성한 리뷰의 수정용 단건 조회 API를 구현했습니다.
- 프론트에서 리뷰 수정 폼 초기값 세팅을 위해 사용할 수 있도록 구성했습니다.

### ✅ 작업 내용
- 단건 조회 API 구현
- 인증 방식 변경: X-USER-ID → Authorization 헤더 (JWT 기반)
- 컨트롤러 경로 정리

### 📚 참고 자료, 할 말
-
