### PR TITLE
[REFACTOR] JWT 토큰 추출 부분을 공통 메서드 사용으로 리팩토링

### DIFF
--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/controller/ReservationController.java
@@ -4,6 +4,7 @@ import goormton.backend.sodamsodam.domain.reservation.dto.request.CreateReservat
 import goormton.backend.sodamsodam.domain.reservation.dto.response.CreateReservationResponse;
 import goormton.backend.sodamsodam.domain.reservation.service.ReservationService;
 import goormton.backend.sodamsodam.global.payload.ResponseCustom;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,10 +18,10 @@ public class ReservationController {
 
     @PostMapping
     public ResponseCustom<CreateReservationResponse> createReservation(
-            @RequestHeader("Authorization") String authHeader,
+            HttpServletRequest request,
             @RequestBody @Valid CreateReservationRequest createReservationRequest
     ) {
-        CreateReservationResponse createReservationResponse = reservationService.createReservation(authHeader, createReservationRequest);
+        CreateReservationResponse createReservationResponse = reservationService.createReservation(request, createReservationRequest);
         return ResponseCustom.CREATED(createReservationResponse);
     }
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
@@ -10,6 +10,7 @@ import goormton.backend.sodamsodam.global.error.DefaultAuthenticationException;
 import goormton.backend.sodamsodam.global.error.DefaultException;
 import goormton.backend.sodamsodam.global.payload.ErrorCode;
 import goormton.backend.sodamsodam.global.util.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,12 +24,12 @@ public class ReservationService {
 
     /**
      * 예약 생성 메서드
-     * @param authHeader
+     * @param request
      * @param createReservationRequest
      * @return 생성된 예약 정보 (reservationId, reservationDate, reservationTime)
      */
-    public CreateReservationResponse createReservation(String authHeader, CreateReservationRequest createReservationRequest) {
-        String token = authHeader.startsWith("Bearer ") ? authHeader.substring(7).trim() : authHeader; // Todo JWT 로직에 추가 요청
+    public CreateReservationResponse createReservation(HttpServletRequest request, CreateReservationRequest createReservationRequest) {
+        String token = jwtUtil.getJwt(request);
 
         if (!jwtUtil.validateToken(token)) {
             throw new DefaultAuthenticationException(ErrorCode.JWT_EXPIRED_ERROR);


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #38 
---
### 📌 요약
- 예약 생성 부분에서 JWT 토큰 추출 로직을 공통 메서드(`getJwt()`)로 대체하였습니다.

### ✅ 작업 내용
- ResercationService 내 `createReservation` 메서드에 있는 기존 토큰 추출 로직을 제거한 후,
- `getJwt(HttpServletRequest request)` 공통 메서드로 대체하였습니다.
- ReservationConroller 내 `createReservation` 메서드 파라미터도 이에 맞게 변경하였습니다.
    - `@RequestHeader("Authorization") String authHeader` 👉🏻 `HttpServletRequest request`

### 📚 참고 자료, 할 말
- 
