### PR TITLE
[FEATURE] 중복 예약 방지 기능 구현

### DIFF
--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/repository/ReservationRepository.java
@@ -4,6 +4,10 @@ import goormton.backend.sodamsodam.domain.reservation.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    boolean existsByPlaceIdAndReservationDateAndReservationTime(String placeId, LocalDate reservationDate, LocalTime reservationTime);
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
@@ -13,6 +13,7 @@ import goormton.backend.sodamsodam.global.util.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -28,6 +29,7 @@ public class ReservationService {
      * @param createReservationRequest
      * @return 생성된 예약 정보 (reservationId, reservationDate, reservationTime)
      */
+    @Transactional
     public CreateReservationResponse createReservation(HttpServletRequest request, CreateReservationRequest createReservationRequest) {
         String token = jwtUtil.getJwt(request);
 

--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
@@ -39,6 +39,16 @@ public class ReservationService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new DefaultException(ErrorCode.USER_NOT_FOUND_ERROR));
 
+        boolean existsReservation = reservationRepository.existsByPlaceIdAndReservationDateAndReservationTime(
+                createReservationRequest.placeId(),
+                createReservationRequest.reservationDate(),
+                createReservationRequest.reservationTime()
+        );
+
+        if (existsReservation) {
+            throw new DefaultAuthenticationException(ErrorCode.RESERVATION_ALREADY_EXISTS_ERROR);
+        }
+
         Reservation reservation = Reservation.builder()
                 .user(user)
                 .placeId(createReservationRequest.placeId())

--- a/src/main/java/goormton/backend/sodamsodam/global/payload/ErrorCode.java
+++ b/src/main/java/goormton/backend/sodamsodam/global/payload/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     BOOKMARK_ALREADY_EXISTS_ERROR(HttpStatus.CONFLICT, null, "이미 북마크된 장소입니다."),
     BOOKMARK_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, null , "해당 장소를 북마크하지 않았습니다."),
 
+    // Reservation Error
+    RESERVATION_ALREADY_EXISTS_ERROR(HttpStatus.CONFLICT, null, "이미 예약이 찬 시간입니다."),
+
     // JWT 토큰
     JWT_EXPIRED_ERROR(HttpStatus.BAD_REQUEST, null, "JWT 토큰이 만료되었습니다."),
     ;


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #41
---
### 📌 요약
- 예약 생성 시 동일한 장소 및 같은 시간대에 예약이 중복되어 생성되지 않도록 중복 방지 로직을 추가했습니다.

### ✅ 작업 내용
- ReservationService의 `createReservation` 메서드에 중복 예약 검증 로직 구현
- ErrorCode에 `RESERVATION_ALREADY_EXISTS_ERROR`를 정의하여 중복 예약 시도 시 에러 메시지 및 상태 코드 반환

### 📚 참고 자료, 할 말
- 더 효율적인 중복 체크 방법이 있다면 알려주시면 감사하겠습니다 ~!
