### PR TITLE
[FEATURE] 장소 검색 시 리뷰 이미지 포함 기능 추가

### DIFF
--- a/src/main/java/goormton/backend/sodamsodam/domain/place/dto/PlaceResponseDto.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/place/dto/PlaceResponseDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -22,13 +24,16 @@ public class PlaceResponseDto {
     @Schema(description = "전체 지번 주소", example = "서울 송파구 신천동 29")
     private String addressName;
 
+    @Schema(description = "장소 리뷰 이미지 URL 목록 (해당 장소의 모든 리뷰 이미지)")
+    private List<String> imageUrls;
 
-    public static PlaceResponseDto from(KakaoPlaceDto.Document document) {
+    public static PlaceResponseDto from(KakaoPlaceDto.Document document, List<String> imageUrls) {
         return new PlaceResponseDto(
                 document.getId(),
                 document.getPlace_name(),
                 document.getPhone(),
-                document.getAddress_name()
+                document.getAddress_name(),
+                imageUrls
         );
     }
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryImpl.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryImpl.java
@@ -26,4 +26,18 @@ public class ImageRepositoryImpl implements ImageRepositoryQueryDsl {
                 .limit(3)
                 .fetch();
     }
+
+    @Override
+    public List<String> findAllUrlsByPlaceId(String placeId) {
+        QImage image = QImage.image;
+        QReview review = QReview.review;
+
+        return queryFactory
+                .select(image.fileUrl)
+                .from(image)
+                .join(image.review, review)
+                .where(review.placeId.eq(placeId))
+                .orderBy(image.createdAt.desc())
+                .fetch();
+    }
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryQueryDsl.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryQueryDsl.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 public interface ImageRepositoryQueryDsl {
     List<String> findTop3UrlsByPlaceId(String placeId);
+    List<String> findAllUrlsByPlaceId(String placeId);
 }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #61 

---
### 📌 요약
- 장소 검색 API에 리뷰 이미지 포함 기능 추가 - 카카오맵 API에서 제공하지 않는 이미지를 리뷰 이미지로 대체

### ✅ 작업 내용
- **PlaceResponseDto 수정**
  - `imageUrls` 필드 추가 (해당 장소의 모든 리뷰 이미지 URL 목록)

- **ImageRepository 확장**
  - `findAllUrlsByPlaceId()` 메서드 추가
  - 장소별 모든 리뷰 이미지 URL을 최신순으로 조회

- **PlaceService 수정**
  - 키워드/카테고리 검색 시 각 장소의 리뷰 이미지 조회 로직 추가
  - `findAllUrlsByPlaceId()` 메서드를 사용하여 이미지 URL 목록 제공
  
### 📚 참고 자료, 할 말
-
