### PR TITLE
[FEATURE] 예약 전체 내역 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/controller/ReservationController.java
@@ -2,12 +2,14 @@ package goormton.backend.sodamsodam.domain.reservation.controller;
 
 import goormton.backend.sodamsodam.domain.reservation.dto.request.CreateReservationRequest;
 import goormton.backend.sodamsodam.domain.reservation.dto.response.CreateReservationResponse;
+import goormton.backend.sodamsodam.domain.reservation.dto.response.ReservationListResponse;
 import goormton.backend.sodamsodam.domain.reservation.service.ReservationService;
 import goormton.backend.sodamsodam.global.payload.ResponseCustom;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/reservations")
@@ -23,6 +25,14 @@ public class ReservationController {
     ) {
         CreateReservationResponse createReservationResponse = reservationService.createReservation(token, createReservationRequest);
         return ResponseCustom.CREATED(createReservationResponse);
+    }
+
+    @GetMapping
+    public ResponseCustom<List<ReservationListResponse>> reservationList(
+            @RequestHeader("Authorization") String token
+    ) {
+        List<ReservationListResponse> reservationListResponses = reservationService.getReservationList(token);
+        return ResponseCustom.OK(reservationListResponses);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/dto/response/ReservationListResponse.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/dto/response/ReservationListResponse.java
@@ -1,0 +1,14 @@
+package goormton.backend.sodamsodam.domain.reservation.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ReservationListResponse(
+        Long reservationId,
+        String placeName,
+        String addressName,
+        String image,
+        LocalDate reservationDate,
+        LocalTime reservationTime
+) {
+}

--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/repository/ReservationRepository.java
@@ -6,8 +6,11 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     boolean existsByPlaceIdAndReservationDateAndReservationTime(String placeId, LocalDate reservationDate, LocalTime reservationTime);
+
+    List<Reservation> findByUserId(Long userId);
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/reservation/service/ReservationService.java
@@ -3,7 +3,9 @@ package goormton.backend.sodamsodam.domain.reservation.service;
 import goormton.backend.sodamsodam.domain.reservation.domain.Reservation;
 import goormton.backend.sodamsodam.domain.reservation.dto.request.CreateReservationRequest;
 import goormton.backend.sodamsodam.domain.reservation.dto.response.CreateReservationResponse;
+import goormton.backend.sodamsodam.domain.reservation.dto.response.ReservationListResponse;
 import goormton.backend.sodamsodam.domain.reservation.repository.ReservationRepository;
+import goormton.backend.sodamsodam.domain.review.repository.ImageRepository;
 import goormton.backend.sodamsodam.domain.user.domain.User;
 import goormton.backend.sodamsodam.domain.user.domain.repository.UserRepository;
 import goormton.backend.sodamsodam.global.error.DefaultAuthenticationException;
@@ -14,12 +16,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
+    private final ImageRepository imageRepository;
     private final JwtUtil jwtUtil;
 
     /**
@@ -67,6 +75,41 @@ public class ReservationService {
                 reservation.getReservationDate(),
                 reservation.getReservationTime()
         );
+    }
+
+    /**
+     * 예약 리스트 조회 메서드
+     * @param token
+     * @return List<ReservationListResponse>
+     */
+    public List<ReservationListResponse> getReservationList(String token) {
+        String accessToken = jwtUtil.getJwt(token);
+
+        // Todo JWT 관련 로직 분리 필요
+        if (!jwtUtil.validateToken(accessToken)) {
+            throw new DefaultAuthenticationException(ErrorCode.JWT_EXPIRED_ERROR);
+        }
+
+        Long userId = jwtUtil.getIdFromToken(accessToken);
+        List<Reservation> reservationList = reservationRepository.findByUserId(userId);
+
+
+
+        List<ReservationListResponse> reservationListResponses = new ArrayList<>();
+        for (Reservation reservation : reservationList) {
+            Long reservationId = reservation.getId();
+            String placeId = reservation.getPlaceId();
+            String placeName = reservation.getPlaceName();
+            String addressName = reservation.getAddressName();
+            String image = imageRepository.findOneImageUrlByPlaceId(placeId);
+            LocalDate reservationDate = reservation.getReservationDate();
+            LocalTime reservationTime = reservation.getReservationTime();
+
+            ReservationListResponse reservationListResponse
+                    = new ReservationListResponse(reservationId, placeName,  addressName, image, reservationDate, reservationTime);
+            reservationListResponses.add(reservationListResponse);
+        }
+        return reservationListResponses;
     }
 
     /**

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/entity/Image.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/entity/Image.java
@@ -35,6 +35,9 @@ public class Image {
     @Column(nullable = false)
     private Long fileSize;              // 파일 크기 (bytes)
 
+    @Column(nullable = false)
+    private String placeId;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryImpl.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryImpl.java
@@ -40,4 +40,15 @@ public class ImageRepositoryImpl implements ImageRepositoryQueryDsl {
                 .orderBy(image.createdAt.desc())
                 .fetch();
     }
+
+    public String findOneImageUrlByPlaceId(String placeId) {
+        QImage image = QImage.image;
+
+        return queryFactory
+                .select(image.fileUrl)
+                .from(image)
+                .where(image.placeId.eq(placeId))
+                .orderBy(image.createdAt.desc())
+                .fetchFirst();
+    }
 }

--- a/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryQueryDsl.java
+++ b/src/main/java/goormton/backend/sodamsodam/domain/review/repository/ImageRepositoryQueryDsl.java
@@ -5,4 +5,5 @@ import java.util.List;
 public interface ImageRepositoryQueryDsl {
     List<String> findTop3UrlsByPlaceId(String placeId);
     List<String> findAllUrlsByPlaceId(String placeId);
+    String findOneImageUrlByPlaceId(String placeId);
 }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #60

---
### 📌 요약
- 본인이 예약한 전체 내역 리스트를 조회하는 기능을 구현했습니다.

### ✅ 작업 내용
- 예약 리스트 조회 시 해당 장소의 이미지를 불러올 수 있도록 Image 테이블에 `placeId`를 추가했습니다.
- 예약 리스트 조회 시 해당 장소의 이미지가 하나만 필요함에 따라, ImageRepositoryImpl에 해당 기능(`findOneImageUrlByPlaceId`)을 구현해두었습니다.

### 📚 참고 자료, 할 말
- 
